### PR TITLE
Add resilience4j dependency and implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ hs_err_pid*
 #INtelij
 *.idea
 *.DS_Store
+*.iml

--- a/README.md
+++ b/README.md
@@ -35,3 +35,36 @@ You can access the DB through pgadmin
     * password: password
     * user: postgres
 
+## Patterns
+
+**TODO: Move these to a wiki**
+
+#### Circuit Breaker Pattern
+
+The `Circuit Breaker Pattern` helps us in preventing a cascade of failures when 
+a remote service is down.
+
+After a number of failed attempts, we can consider that the service is unavailable/overloaded
+and eagerly reject all subsequent requests to it. In this way, we can save system
+resources for calls which are likely to fail. 
+
+##### Resilience4j Circuit Breaker
+The circuitBreaker is implemented via a finite state machine with three normal states:
+CLOSED, OPEN, and HALF_OPEN and two special states DISABLED and FORCED_OPEN.
+
+The state of the CircuitBreaker changes from CLOSED to OPEN when the failure rate is above a 
+configurable threshold. Then all calls are rejected for a configurable time diration. 
+
+After the time duration has elapsed, the CircuitBreaker state changes from OPEN to HALF_OPEN and
+allows a configurable number of calls to see if the backend is still unavailable or has become available again. 
+
+
+More information can be found here: https://resilience4j.readme.io/docs/circuitbreaker
+Resilience4j demo: https://github.com/resilience4j/resilience4j-spring-boot2-demo
+
+#### Bulkhead Pattern
+
+The goal of the bulkhead pattern is to avoid faults in one part of a system to tae the entire
+system down. The term comes from ships where a ship is divided in separate watertight
+compartments to avoid a single hull breach to flood the entire ship; it will only
+flood one bulkhead.

--- a/pom.xml
+++ b/pom.xml
@@ -17,31 +17,69 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
+		<resilience4j.version>0.17.0</resilience4j.version>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
 
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot2</artifactId>
+			<version>${resilience4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-reactor</artifactId>
+			<version>${resilience4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.vavr</groupId>
+			<artifactId>vavr-jackson</artifactId>
+			<version>0.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-circuitbreaker</artifactId>
+			<version>0.17.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
+++ b/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
@@ -1,7 +1,7 @@
 package com.fcgl.madrid.dev;
 
-import com.fcgl.madrid.forum.model.Comment;
-import com.fcgl.madrid.forum.model.Post;
+import com.fcgl.madrid.forum.dataModel.Comment;
+import com.fcgl.madrid.forum.dataModel.Post;
 import com.fcgl.madrid.forum.repository.CommentRepository;
 import com.fcgl.madrid.forum.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/fcgl/madrid/dev/DevController.java
+++ b/src/main/java/com/fcgl/madrid/dev/DevController.java
@@ -1,0 +1,24 @@
+package com.fcgl.madrid.dev;
+
+import com.fcgl.madrid.forum.model.InternalStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/dev/")
+public class DevController {
+
+    DevService devService;
+
+    @Autowired
+    public void setPostService(DevService devService) {
+        this.devService = devService;
+    }
+
+    @GetMapping(value="/fallback")
+    public ResponseEntity<InternalStatus> failureWithFallback() {
+        return devService.failureWithFallback();
+    }
+}

--- a/src/main/java/com/fcgl/madrid/dev/DevService.java
+++ b/src/main/java/com/fcgl/madrid/dev/DevService.java
@@ -1,0 +1,38 @@
+package com.fcgl.madrid.dev;
+import com.fcgl.madrid.forum.model.InternalStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+
+import java.lang.IllegalArgumentException;
+
+
+@Service
+public class DevService {
+
+    public ResponseEntity<InternalStatus> failure() {
+        throw new IllegalArgumentException("TESTING TESTING TESTING");
+    }
+
+    @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
+    public ResponseEntity<InternalStatus> failureWithFallback() {
+        return failure();
+    }
+
+    private ResponseEntity<InternalStatus> fallback(IllegalArgumentException ex) {
+        String message = "Fallback: " + ex.getMessage();
+        InternalStatus internalStatus = new InternalStatus(-1, 400, message);
+        return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.BAD_REQUEST);
+    }
+
+    private ResponseEntity<InternalStatus> fallback(CallNotPermittedException ex) {
+        String message = "Fallback: " + ex.getMessage();
+        InternalStatus internalStatus = new InternalStatus(-1, 500, message);
+        return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
@@ -3,8 +3,6 @@ package com.fcgl.madrid.forum.controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/forum/comment/v1")
 public class CommentController {

--- a/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
@@ -1,6 +1,6 @@
 package com.fcgl.madrid.forum.controller;
 
-import com.fcgl.madrid.forum.model.Post;
+import com.fcgl.madrid.forum.dataModel.Post;
 import com.fcgl.madrid.forum.service.PostService;
 import com.fcgl.madrid.healthcheck.model.Health;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +13,7 @@ import java.util.List;
 @RequestMapping("/forum/post/v1")
 public class PostController {
 
-    PostService postService;
+    private PostService postService;
 
     @Autowired
     public void setPostService(PostService postService) {

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/Comment.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/Comment.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.forum.model;
+package com.fcgl.madrid.forum.dataModel;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.forum.model;
+package com.fcgl.madrid.forum.dataModel;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 

--- a/src/main/java/com/fcgl/madrid/forum/model/InternalStatus.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/InternalStatus.java
@@ -1,0 +1,33 @@
+package com.fcgl.madrid.forum.model;
+
+public class InternalStatus {
+    public static final InternalStatus OK = new InternalStatus(1, 200, "ok");
+    public static final InternalStatus MISSING_PARAM = new InternalStatus(2, 400, "Missing Required Param");
+
+    private int code;
+    private int httpCode;
+    private String message;
+
+    public InternalStatus() {
+
+    }
+
+    public InternalStatus(int code, int httpCode, String message) {
+        this.code = code;
+        this.httpCode = httpCode;
+        this.message = message;
+    }
+
+
+    public int getCode() {
+        return this.code;
+    }
+
+    public int getHttpCode() {
+        return this.httpCode;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/repository/CommentRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/CommentRepository.java
@@ -1,6 +1,6 @@
 package com.fcgl.madrid.forum.repository;
 
-import com.fcgl.madrid.forum.model.Comment;
+import com.fcgl.madrid.forum.dataModel.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {

--- a/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
@@ -1,6 +1,6 @@
 package com.fcgl.madrid.forum.repository;
 
-import com.fcgl.madrid.forum.model.Post;
+import com.fcgl.madrid.forum.dataModel.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {

--- a/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
@@ -1,6 +1,6 @@
 package com.fcgl.madrid.forum.service;
 
-import com.fcgl.madrid.forum.model.Comment;
+import com.fcgl.madrid.forum.dataModel.Comment;
 import com.fcgl.madrid.forum.repository.CommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/fcgl/madrid/forum/service/PostService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/PostService.java
@@ -1,6 +1,6 @@
 package com.fcgl.madrid.forum.service;
 
-import com.fcgl.madrid.forum.model.Post;
+import com.fcgl.madrid.forum.dataModel.Post;
 import com.fcgl.madrid.forum.repository.PostRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.datasource.username=postgres
 spring.datasource.password=password
 
 spring.jpa.hibernate.ddl-auto=create
+
+logging.level.org.springframework.web: DEBUG
+logging.level.org.hibernate: ERROR

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,19 @@ ribbon:
   eureka:
     enabled: true
 
+
+#Resilience4j config: Have to run some tests to figure out best config
+resilience4j.circuitbreaker:
+  configs:
+    default:
+      registerHealthIndicator: true
+      ringBufferSizeInClosedState: 10
+      ringBufferSizeInHalfOpenState: 3
+      waitDurationInOpenState: 2s
+      failureRateThreshold: 30
+      eventConsumerBufferSize: 10
+#      ignoreExceptions:
+  instances:
+    backendA:
+      baseConfig: default
+


### PR DESCRIPTION
## Problem
Need a fault tolerance library in our service

## Solution
Implement resilience4j for fault tolerance. This PR only implements Circuit Breakers but other useful tools can be added 

You can find out more about resilience4j here: https://resilience4j.readme.io/docs/

## Test
1. build and run: `docker-compose up --build`
2. Go to http://localhost:8082/dev/fallback and verify that you get the following response:
`{"code":-1,"httpCode":400,"message":"Fallback: TESTING TESTING TESTING"}`
3. Keep refreshing the page (about 10-12 times), verify that you get this new response:
`{"code":-1,"httpCode":500,"message":"Fallback: CircuitBreaker 'backendA' is OPEN and does not permit further calls"}`

Explanation: the http://localhost:8082/dev/fallback endpoint is always returning an IllegalArgumentException. The fallback for that exception is `{"code":-1,"httpCode":400,"message":"Fallback: TESTING TESTING TESTING"}`. When you keep refreshing the page, the server notices that the same exception is being thrown. So the server now rejects the requests for a set number of seconds. 

This would be useful in cases where our database related queries are taking too long and timing out. It would give our database some breathing room to try to catch itself up. 