### PR TITLE
Add two new endpoints to get an individual Post, and to get paginated comments

### DIFF
--- a/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
+++ b/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
@@ -33,7 +33,15 @@ public class DataPopulation {
         postRepository.save(post1);
         postRepository.save(post2);
         postRepository.save(post3);
-        Comment comment1 = new Comment("Testing Comment for post 1", post1, 1);
+        Comment comment1 = new Comment("Testing Comment #1 for post 1", post1, 1);
+        Comment comment2 = new Comment("Testing Comment #2 for post 1", post1, 2);
+        Comment comment3 = new Comment("Testing Comment #3 for post 1", post1, 5);
+        Comment comment4 = new Comment("Testing Comment #4 for post 1", post1, 3);
+        Comment comment5 = new Comment("Testing Comment #5 for post 1", post1, 4);
         commentRepository.save(comment1);
+        commentRepository.save(comment2);
+        commentRepository.save(comment3);
+        commentRepository.save(comment4);
+        commentRepository.save(comment5);
     }
 }

--- a/src/main/java/com/fcgl/madrid/dev/DevController.java
+++ b/src/main/java/com/fcgl/madrid/dev/DevController.java
@@ -1,6 +1,6 @@
 package com.fcgl.madrid.dev;
 
-import com.fcgl.madrid.forum.model.InternalStatus;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/fcgl/madrid/dev/DevService.java
+++ b/src/main/java/com/fcgl/madrid/dev/DevService.java
@@ -1,9 +1,8 @@
 package com.fcgl.madrid.dev;
-import com.fcgl.madrid.forum.model.InternalStatus;
-import com.fcgl.madrid.forum.model.StatusCode;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.response.StatusCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;

--- a/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
@@ -27,8 +27,8 @@ public class CommentController {
         return commentService.postComment(commentRequest);
     }
 
-    @GetMapping(path = "/postComment")
-    public ResponseEntity<GetPostCommentResponse> postComment(GetPostCommentRequest request) {
+    @GetMapping(path = "/getComment")
+    public ResponseEntity<GetPostCommentResponse> getPostComments(GetPostCommentRequest request) {
         return commentService.getPostComments(request);
     }
 

--- a/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
@@ -1,7 +1,7 @@
 package com.fcgl.madrid.forum.controller;
 
-import com.fcgl.madrid.forum.model.CommentRequest;
-import com.fcgl.madrid.forum.model.InternalStatus;
+import com.fcgl.madrid.forum.model.request.CommentRequest;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
 import com.fcgl.madrid.forum.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
@@ -1,11 +1,14 @@
 package com.fcgl.madrid.forum.controller;
 
 import com.fcgl.madrid.forum.model.request.CommentRequest;
+import com.fcgl.madrid.forum.model.request.GetPostCommentRequest;
+import com.fcgl.madrid.forum.model.response.GetPostCommentResponse;
 import com.fcgl.madrid.forum.model.response.InternalStatus;
 import com.fcgl.madrid.forum.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +21,16 @@ public class CommentController {
     public void setCommentService(CommentService commentService) {
         this.commentService = commentService;
     }
+
     @PostMapping(path = "/postComment")
     public ResponseEntity<InternalStatus> postComment(CommentRequest commentRequest) {
         return commentService.postComment(commentRequest);
     }
+
+    @GetMapping(path = "/postComment")
+    public ResponseEntity<GetPostCommentResponse> postComment(GetPostCommentRequest request) {
+        return commentService.getPostComments(request);
+    }
+
 
 }

--- a/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
@@ -49,7 +49,7 @@ public class PostController {
         return postService.post(postRequest);
     }
 
-    @GetMapping(path="/post")
+    @GetMapping(path="/getPost")
     public ResponseEntity<GetPostResponse> getPost(Long postId) {
         return postService.getPost(postId);
     }

--- a/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
@@ -1,15 +1,17 @@
 package com.fcgl.madrid.forum.controller;
 
 import com.fcgl.madrid.forum.dataModel.Post;
-import com.fcgl.madrid.forum.model.InternalStatus;
-import com.fcgl.madrid.forum.model.PostRequest;
+import com.fcgl.madrid.forum.model.response.GetPostResponse;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.request.PostRequest;
 import com.fcgl.madrid.forum.service.PostService;
 import com.fcgl.madrid.healthcheck.model.Health;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.List;
 
@@ -46,4 +48,10 @@ public class PostController {
     public ResponseEntity<InternalStatus> post(PostRequest postRequest) {
         return postService.post(postRequest);
     }
+
+    @GetMapping(path="/post")
+    public ResponseEntity<GetPostResponse> getPost(Long postId) {
+        return postService.getPost(postId);
+    }
+
 }

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/IBasicPost.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/IBasicPost.java
@@ -1,0 +1,18 @@
+package com.fcgl.madrid.forum.dataModel;
+
+/**
+ * POST without comments
+ * Used in queries
+ */
+public interface IBasicPost {
+    Long getId();
+    String getTitle();
+    String getDescription();
+    long getCreatedDate();
+    long getUpdatedDate();
+    Integer getLikes();
+    Integer getDislikes();
+    Integer getCityId();
+    Integer getUserId();
+
+}

--- a/src/main/java/com/fcgl/madrid/forum/model/request/CommentRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/CommentRequest.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.forum.model;
+package com.fcgl.madrid.forum.model.request;
 
 import com.fcgl.madrid.forum.dataModel.Post;
 

--- a/src/main/java/com/fcgl/madrid/forum/model/request/GetPostCommentRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/GetPostCommentRequest.java
@@ -1,0 +1,38 @@
+package com.fcgl.madrid.forum.model.request;
+
+public class GetPostCommentRequest {
+
+    private Long postId;
+    private int page;
+    private int size;
+
+    public GetPostCommentRequest(Long postId, int page, int size) {
+        this.postId = postId;
+        this.page = page;
+        this.size = size;
+    }
+
+    public Long getPostId() {
+        return postId;
+    }
+
+    public void setPostId(Long postId) {
+        this.postId = postId;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/model/request/PostRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/PostRequest.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.forum.model;
+package com.fcgl.madrid.forum.model.request;
 
 public class PostRequest {
 

--- a/src/main/java/com/fcgl/madrid/forum/model/response/GetPostCommentResponse.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/GetPostCommentResponse.java
@@ -1,0 +1,30 @@
+package com.fcgl.madrid.forum.model.response;
+
+import com.fcgl.madrid.forum.dataModel.Comment;
+import java.util.List;
+
+public class GetPostCommentResponse {
+    private InternalStatus status;
+    private List<Comment> comments;
+
+    public GetPostCommentResponse(InternalStatus status, List<Comment> comments) {
+        this.status = status;
+        this.comments = comments;
+    }
+
+    public InternalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(InternalStatus status) {
+        this.status = status;
+    }
+
+    public List<Comment> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/model/response/GetPostResponse.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/GetPostResponse.java
@@ -1,0 +1,29 @@
+package com.fcgl.madrid.forum.model.response;
+
+import com.fcgl.madrid.forum.dataModel.IBasicPost;
+
+public class GetPostResponse {
+    private InternalStatus status;
+    private IBasicPost post;
+
+    public GetPostResponse(InternalStatus status, IBasicPost post) {
+        this.status = status;
+        this.post = post;
+    }
+
+    public InternalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(InternalStatus status) {
+        this.status = status;
+    }
+
+    public IBasicPost getPost() {
+        return post;
+    }
+
+    public void setPost(IBasicPost post) {
+        this.post = post;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/model/response/InternalStatus.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/InternalStatus.java
@@ -1,10 +1,12 @@
-package com.fcgl.madrid.forum.model;
+package com.fcgl.madrid.forum.model.response;
+
 import java.util.List;
 import java.util.ArrayList;
 
 public class InternalStatus {
     public static final InternalStatus OK = new InternalStatus(StatusCode.OK, 200, "ok");
     public static final InternalStatus MISSING_PARAM = new InternalStatus(StatusCode.PARAM, 400, "Missing Required Param");
+    public static final InternalStatus NOT_FOUND = new InternalStatus(StatusCode.NOT_FOUND, 404, "Data Not Found");
 
     private int code;
     private int httpCode;

--- a/src/main/java/com/fcgl/madrid/forum/model/response/StatusCode.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/StatusCode.java
@@ -1,9 +1,10 @@
-package com.fcgl.madrid.forum.model;
+package com.fcgl.madrid.forum.model.response;
 
 public class StatusCode {
     public static final StatusCode UNKNOWN = new StatusCode(-1);
     public static final StatusCode OK = new StatusCode(1);
     public static final StatusCode PARAM = new StatusCode(2);
+    public static final StatusCode NOT_FOUND = new StatusCode(3);
 
     private int code;
 

--- a/src/main/java/com/fcgl/madrid/forum/repository/CommentRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package com.fcgl.madrid.forum.repository;
 
 import com.fcgl.madrid.forum.dataModel.Comment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByPostId(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
@@ -1,7 +1,17 @@
 package com.fcgl.madrid.forum.repository;
 
 import com.fcgl.madrid.forum.dataModel.Post;
+import com.fcgl.madrid.forum.dataModel.IBasicPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * Queries the database for Post data without comments
+     * @param id Long: The id for the post being queried
+     * @return IBasicPost
+     */
+    @Query("SELECT u FROM Post u WHERE u.id = ?1")
+    IBasicPost getPost(Long id);
 }

--- a/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
@@ -1,11 +1,9 @@
 package com.fcgl.madrid.forum.service;
 
 import com.fcgl.madrid.forum.dataModel.Comment;
-import com.fcgl.madrid.forum.dataModel.Post;
-import com.fcgl.madrid.forum.model.CommentRequest;
-import com.fcgl.madrid.forum.model.InternalStatus;
-import com.fcgl.madrid.forum.model.PostRequest;
-import com.fcgl.madrid.forum.model.StatusCode;
+import com.fcgl.madrid.forum.model.request.CommentRequest;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.response.StatusCode;
 import com.fcgl.madrid.forum.repository.CommentRepository;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
@@ -2,11 +2,15 @@ package com.fcgl.madrid.forum.service;
 
 import com.fcgl.madrid.forum.dataModel.Comment;
 import com.fcgl.madrid.forum.model.request.CommentRequest;
+import com.fcgl.madrid.forum.model.request.GetPostCommentRequest;
+import com.fcgl.madrid.forum.model.response.GetPostCommentResponse;
 import com.fcgl.madrid.forum.model.response.InternalStatus;
 import com.fcgl.madrid.forum.model.response.StatusCode;
 import com.fcgl.madrid.forum.repository.CommentRepository;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -48,6 +52,14 @@ public class CommentService implements ICommentService {
         }
     }
 
+    @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
+    public ResponseEntity<GetPostCommentResponse> getPostComments(GetPostCommentRequest request) {
+        Pageable pageConfig = PageRequest.of(request.getPage(), request.getSize());
+        List<Comment> comments = commentRepository.findAllByPostId(request.getPostId(), pageConfig);
+        GetPostCommentResponse response = new GetPostCommentResponse(InternalStatus.OK, comments);
+        return new ResponseEntity<GetPostCommentResponse>(response, HttpStatus.OK);
+    }
+
     /**
      * Handles Exceptions dealing with parameters
      * @param e TransactionSystemException
@@ -82,9 +94,21 @@ public class CommentService implements ICommentService {
      * @param ex Exception
      * @return ResponseEntity<InternalStatus>
      */
-    private ResponseEntity<InternalStatus> fallback(Exception ex) {
+    private ResponseEntity<InternalStatus> fallback(CommentRequest commentRequest, Exception ex) {
         String message = "Fallback: " + ex.getMessage();
         InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, message);
         return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     *
+     * @param ex Exception
+     * @return ResponseEntity<InternalStatus>
+     */
+    private ResponseEntity<GetPostCommentResponse> fallback(GetPostCommentRequest request, Exception ex) {
+        String message = "Fallback: " + ex.getMessage();
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, message);
+        GetPostCommentResponse response = new GetPostCommentResponse(internalStatus, null);
+        return new ResponseEntity<GetPostCommentResponse>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/service/IPostService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/IPostService.java
@@ -1,7 +1,7 @@
 package com.fcgl.madrid.forum.service;
 
-import com.fcgl.madrid.forum.model.InternalStatus;
-import com.fcgl.madrid.forum.model.PostRequest;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.request.PostRequest;
 import org.springframework.http.ResponseEntity;
 
 public interface IPostService {

--- a/src/test/java/com/fcgl/madrid/repository/PostRepositoryIntegrationTest.java
+++ b/src/test/java/com/fcgl/madrid/repository/PostRepositoryIntegrationTest.java
@@ -1,8 +1,8 @@
 package com.fcgl.madrid.repository;
 
 import com.fcgl.madrid.MadridApplication;
-import com.fcgl.madrid.forum.model.InternalStatus;
-import com.fcgl.madrid.forum.model.PostRequest;
+import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.request.PostRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.BeforeClass;


### PR DESCRIPTION
## Problem

Trello Ticket: https://trello.com/c/4W1ygeyV/9-get-request-for-post-with-comments
Users need to be able to open up a Post and see its contents: The Post and it's corresponding comments

If there are many comments pagination is needed

## Solution
Couldn't do pagination with only one query. So Decided to introduce two requests.

1. `/forum/comment/v1/postComment`
    * Get's specific post's paginated comments
2. `/forum/post/v1/post`
    * Get's post data without the comments

## Testing

1. Endpoint `/forum/comment/v1/postComment` takes in three params: **postId**, **page**, **size**
    * Try out a variation of these: http://localhost:8082/forum/comment/v1/getComment?postId=1&page=0&size=2

2. Endpoint `/forum/post/v1/post` takes in one param: **postId**
    * http://localhost:8082/forum/post/v1/getPost?postId=1