### PR TITLE
Add endpoint to get Post Attributes (Comment count and Like count

### DIFF
--- a/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
@@ -4,6 +4,7 @@ import com.fcgl.madrid.forum.dataModel.Post;
 import com.fcgl.madrid.forum.model.request.GetCityPostsRequest;
 import com.fcgl.madrid.forum.model.request.PostLikeRequest;
 import com.fcgl.madrid.forum.model.response.GetCityPostsResponse;
+import com.fcgl.madrid.forum.model.response.GetPostInteractionData;
 import com.fcgl.madrid.forum.model.response.GetPostResponse;
 import com.fcgl.madrid.forum.model.response.InternalStatus;
 import com.fcgl.madrid.forum.model.request.PostRequest;
@@ -67,4 +68,18 @@ public class PostController {
         return postService.postLike(request);
     }
 
+    @GetMapping(path="/postLikeCount")
+    public ResponseEntity<GetPostInteractionData> getPostLikeCount(Long postId) {
+        return postService.getPostLikeCount(postId);
+    }
+
+    @GetMapping(path="/postCommentCount")
+    public ResponseEntity<GetPostInteractionData> getPostCommentCount(Long postId) {
+        return postService.getPostCommentCount(postId);
+    }
+
+    @GetMapping(path="/postInteractionData")
+    public ResponseEntity<GetPostInteractionData> getPostInteractionData(Long postId) {
+        return postService.getPostInteractionData(postId);
+    }
 }

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/IBasicPost.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/IBasicPost.java
@@ -10,10 +10,7 @@ public interface IBasicPost {
     String getDescription();
     long getCreatedDate();
     long getUpdatedDate();
-    Integer getLikes();
-    Integer getDislikes();
     Integer getCityId();
     Long getUserId();
-    Integer getCommentSize();
 
 }

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
@@ -25,8 +25,6 @@ public class Post {
     private String description;
     private long createdDate;
     private long updatedDate;
-    private Integer likes;
-    private Integer dislikes;
     @NotNull
     private Integer cityId;//TODO: Think about location better than this
     @NotNull
@@ -39,7 +37,6 @@ public class Post {
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     @JsonManagedReference
     private List<UserLike> userLikes;
-    private Integer commentSize;
 
     public Post() {
     }
@@ -49,12 +46,9 @@ public class Post {
         this.title = title;
         this.description = description;
         this.cityId = cityId;
-        this.likes = new Integer(0);
-        this.dislikes = new Integer(0);
         this.createdDate = Instant.now().toEpochMilli();
         this.updatedDate = this.createdDate;
         this.comment = new ArrayList<Comment>();
-        this.commentSize = new Integer(0);//Optimized so that POST reads are faster
         this.userLikes = new ArrayList<UserLike>();
     }
 
@@ -90,22 +84,6 @@ public class Post {
         this.updatedDate = updatedDate;
     }
 
-    public Integer getLikes() {
-        return likes;
-    }
-
-    public void setLikes(Integer likes) {
-        this.likes = likes;
-    }
-
-    public Integer getDislikes() {
-        return dislikes;
-    }
-
-    public void setDislikes(Integer dislikes) {
-        this.dislikes = dislikes;
-    }
-
     public Integer getCityId() {
         return cityId;
     }
@@ -116,14 +94,6 @@ public class Post {
 
     public List<Comment> getComment() {
         return comment;
-    }
-
-    public Integer getCommentSize() {
-        return commentSize;
-    }
-
-    public void setCommentSize(Integer commentSize) {
-        this.commentSize = commentSize;
     }
 
     public List<UserLike> getUserLikes() {

--- a/src/main/java/com/fcgl/madrid/forum/model/response/GetPostInteractionData.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/GetPostInteractionData.java
@@ -1,0 +1,39 @@
+package com.fcgl.madrid.forum.model.response;
+
+public class GetPostInteractionData {
+
+    private Integer likeCount;
+    private Integer commentCount;
+    private InternalStatus internalStatus;
+
+    public GetPostInteractionData(Integer likeCount, Integer commentCount, InternalStatus internalStatus) {
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.internalStatus = internalStatus;
+    }
+
+
+    public Integer getLikeCount() {
+        return likeCount;
+    }
+
+    public void setLikeCount(Integer likeCount) {
+        this.likeCount = likeCount;
+    }
+
+    public Integer getCommentCount() {
+        return commentCount;
+    }
+
+    public void setCommentCount(Integer commentCount) {
+        this.commentCount = commentCount;
+    }
+
+    public InternalStatus getInternalStatus() {
+        return internalStatus;
+    }
+
+    public void setInternalStatus(InternalStatus internalStatus) {
+        this.internalStatus = internalStatus;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/repository/CommentRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/CommentRepository.java
@@ -1,13 +1,16 @@
 package com.fcgl.madrid.forum.repository;
 
 import com.fcgl.madrid.forum.dataModel.Comment;
+import com.fcgl.madrid.forum.dataModel.Post;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPostId(Long postId, Pageable pageable);
 
-    Integer countByPost(Long postId);
+    Integer countByPostId(Long postId);
 }

--- a/src/main/java/com/fcgl/madrid/forum/repository/UserLikeRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/UserLikeRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserLikeRepository extends JpaRepository<UserLike, Long>  {
 
     UserLike findUserLikeByUserIdAndPost(Long userId, Post post);
+
+    Integer countByPostId(Long postId);
 }

--- a/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
@@ -59,30 +59,9 @@ public class CommentService implements ICommentService {
             return handleParamException(e);
         }
 
-        boolean success = updatePostCommentCount(commentRequest.getPost(), new Integer(1));
-        if (!success) {
-            logger.warn(new String("UPDATE POST COMMENT COUNT FAILED FOR POST: " + Long.toString(commentRequest.getPost().getId())));
-        }
         return new ResponseEntity<InternalStatus>(InternalStatus.OK, HttpStatus.OK);
     }
 
-    /**
-     * Adds a count to the number of comments. Follows the "eventually consistent strategy".
-     * If this function throws and exception it wont stop the request that calls this function
-     * @param post
-     * @param count
-     * @return
-     */
-    private boolean updatePostCommentCount(Post post, Integer count) {
-        try {
-            post.setCommentSize(post.getCommentSize() + count);
-            postRepository.save(post);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-
-    }
     @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
     public ResponseEntity<GetPostCommentResponse> getPostComments(GetPostCommentRequest request) {
         Pageable pageConfig = PageRequest.of(request.getPage(), request.getSize());


### PR DESCRIPTION
## Problem
User's need to have the ability to see how many likes and comments a post has before expanding on it

## Solution
Add three endpoints
1. Get Post User Like Count
2. Get Post Comment Count
3. Get Post User Like Count and Comment Count

## Test
1. http://localhost:8082/forum/post/v1/postCommentCount?postId=1
2. http://localhost:8082/forum/post/v1/postLikeCount?postId=1
3. http://localhost:8082/forum/post/v1/postInteractionData?postId=1
