### PR TITLE
Update cityPosts endpoint to contain more user attribute data

### DIFF
--- a/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
+++ b/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
@@ -2,8 +2,10 @@ package com.fcgl.madrid.dev;
 
 import com.fcgl.madrid.forum.dataModel.Comment;
 import com.fcgl.madrid.forum.dataModel.Post;
+import com.fcgl.madrid.forum.dataModel.UserLike;
 import com.fcgl.madrid.forum.repository.CommentRepository;
 import com.fcgl.madrid.forum.repository.PostRepository;
+import com.fcgl.madrid.forum.repository.UserLikeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
@@ -17,19 +19,21 @@ public class DataPopulation {
 
     private PostRepository postRepository;
     private CommentRepository commentRepository;
+    private UserLikeRepository userLikeRepository;
 
     @Autowired
-    public DataPopulation(PostRepository postRepository, CommentRepository commentRepository) {
+    public DataPopulation(PostRepository postRepository, CommentRepository commentRepository, UserLikeRepository userLikeRepository) {
         this.postRepository = postRepository;
         this.commentRepository = commentRepository;
+        this.userLikeRepository = userLikeRepository;
     }
 
     @Transactional
     @PostConstruct
     public void init() {
-        Post post1 = new Post("Title 1", "This is test number one", 1, new Long(1));
-        Post post2 = new Post("Title 2", "This is test number two", 1, new Long(2));
-        Post post3 = new Post("Title 3", "This is test number three", 1, new Long(3));
+        Post post1 = new Post("Title 1", "This is test number one", 1, new Long(1), "Jean Paul");
+        Post post2 = new Post("Title 2", "This is test number two", 1, new Long(2), "Miles");
+        Post post3 = new Post("Title 3", "This is test number three", 1, new Long(3), "Ben");
         postRepository.save(post1);
         postRepository.save(post2);
         postRepository.save(post3);
@@ -43,5 +47,14 @@ public class DataPopulation {
         commentRepository.save(comment3);
         commentRepository.save(comment4);
         commentRepository.save(comment5);
+        UserLike userLike1 = new UserLike(1L, post1);
+        UserLike userLike2 = new UserLike(2L, post1);
+        UserLike userLike3 = new UserLike(3L, post1);
+        UserLike userLike4 = new UserLike(4L, post1);
+        userLikeRepository.save(userLike1);
+        userLikeRepository.save(userLike2);
+        userLikeRepository.save(userLike3);
+        userLikeRepository.save(userLike4);
+
     }
 }

--- a/src/main/java/com/fcgl/madrid/dev/DevService.java
+++ b/src/main/java/com/fcgl/madrid/dev/DevService.java
@@ -25,13 +25,13 @@ public class DevService {
 
     private ResponseEntity<InternalStatus> fallback(IllegalArgumentException ex) {
         String message = "Fallback: " + ex.getMessage();
-        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 400, message);
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, HttpStatus.BAD_REQUEST, message);
         return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.BAD_REQUEST);
     }
 
     private ResponseEntity<InternalStatus> fallback(CallNotPermittedException ex) {
         String message = "Fallback: " + ex.getMessage();
-        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, message);
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR, message);
         return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
@@ -12,11 +12,10 @@ import com.fcgl.madrid.forum.service.PostService;
 import com.fcgl.madrid.healthcheck.model.Health;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
+//import org.springframework.security.core.context.SecurityContextHolder;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -59,12 +58,12 @@ public class PostController {
     }
 
     @GetMapping(path="/cityPosts")
-    public ResponseEntity<GetCityPostsResponse> getCityPosts(GetCityPostsRequest request) {
+    public ResponseEntity<GetCityPostsResponse> getCityPosts(@Valid GetCityPostsRequest request) {
         return postService.getCityPosts(request);
     }
 
     @PostMapping(path="/like")
-    public ResponseEntity<InternalStatus> postLike(PostLikeRequest request) {
+    public ResponseEntity<InternalStatus> postLike(@Valid @RequestBody PostLikeRequest request) {
         return postService.postLike(request);
     }
 

--- a/src/main/java/com/fcgl/madrid/forum/controller/exceptionHandler/CustomExceptionHandler.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/exceptionHandler/CustomExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.fcgl.madrid.forum.controller.exceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.response.Response;
+import com.fcgl.madrid.forum.model.response.StatusCode;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@ControllerAdvice
+public class CustomExceptionHandler extends ResponseEntityExceptionHandler{
+
+
+    @Override
+    protected ResponseEntity<Object> handleBindException(
+            BindException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        return genericErrorHandler(ex, ex.getBindingResult(), headers, status, request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        return genericErrorHandler(ex, ex.getBindingResult(), headers, status, request);
+
+    }
+
+    private ResponseEntity<Object> genericErrorHandler(
+            Exception ex,
+            BindingResult bindingResult,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        List<String> errors = new ArrayList<String>();
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            errors.add(error.getField() + " " + error.getDefaultMessage());
+        }
+        for (ObjectError error : bindingResult.getGlobalErrors()) {
+            errors.add(error.getObjectName() + " " + error.getDefaultMessage());
+        }
+
+        InternalStatus internalStatus = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, errors);
+        Response loginResponse = new Response<>(internalStatus, null);
+        return handleExceptionInternal(
+                ex, loginResponse, headers, internalStatus.getHttpCode(), request);
+    }
+
+}
+

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/IBasicPost.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/IBasicPost.java
@@ -12,5 +12,7 @@ public interface IBasicPost {
     long getUpdatedDate();
     Integer getCityId();
     Long getUserId();
-
+    Integer getUserLikeCount();
+    Integer getUserCommentCount();
+    String getUserFirstName();
 }

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
@@ -13,6 +13,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Post table
+ * params userLikeCount and userCommentCount follow the eventually consistent pattern.
+ * Will be updated when a user requests the data and it's been over 1 minute since the last update
+ */
 @Entity
 public class Post {
 
@@ -29,6 +34,9 @@ public class Post {
     private Integer cityId;//TODO: Think about location better than this
     @NotNull
     private Long userId;
+    private Integer userLikeCount;
+    private Integer userCommentCount;
+    private String userFirstName;
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     @JsonManagedReference
@@ -38,18 +46,26 @@ public class Post {
     @JsonManagedReference
     private List<UserLike> userLikes;
 
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedDate = Instant.now().toEpochMilli();
+    }
+
     public Post() {
     }
 
-    public Post(String title, String description, Integer cityId, Long userId) {
+    public Post(String title, String description, Integer cityId, Long userId, String userFirstName) {
         this.userId = userId;
         this.title = title;
         this.description = description;
         this.cityId = cityId;
+        this.userFirstName = userFirstName;
         this.createdDate = Instant.now().toEpochMilli();
         this.updatedDate = this.createdDate;
         this.comment = new ArrayList<Comment>();
         this.userLikes = new ArrayList<UserLike>();
+        this.userLikeCount = 0;
+        this.userCommentCount = 0;
     }
 
     public Long getId() {
@@ -102,5 +118,29 @@ public class Post {
 
     public void setUserLikes(List<UserLike> userLikes) {
         this.userLikes = userLikes;
+    }
+
+    public Integer getUserLikeCount() {
+        return userLikeCount;
+    }
+
+    public void setUserLikeCount(Integer userLikeCount) {
+        this.userLikeCount = userLikeCount;
+    }
+
+    public Integer getUserCommentCount() {
+        return userCommentCount;
+    }
+
+    public void setUserCommentCount(Integer userCommentCount) {
+        this.userCommentCount = userCommentCount;
+    }
+
+    public String getUserFirstName() {
+        return userFirstName;
+    }
+
+    public void setUserFirstName(String userFirstName) {
+        this.userFirstName = userFirstName;
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/request/GetCityPostsRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/GetCityPostsRequest.java
@@ -1,16 +1,25 @@
 package com.fcgl.madrid.forum.model.request;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
 public class GetCityPostsRequest {
 
+    @NotNull
     private Integer cityId;
-    private int page;
-    private int size;
+    @NotNull
+    private Integer page;
+    @NotNull
+    private Integer size;
+
+    private Long userId;
 
 
-    public GetCityPostsRequest(Integer cityId, int page, int size) {
+    public GetCityPostsRequest(Integer cityId, Integer page, Integer size, Long userId) {
         this.cityId = cityId;
         this.page = page;
         this.size = size;
+        this.userId = userId;
     }
 
     public Integer getCityId() {
@@ -21,19 +30,27 @@ public class GetCityPostsRequest {
         this.cityId = cityId;
     }
 
-    public int getPage() {
+    public Integer getPage() {
         return page;
     }
 
-    public void setPage(int page) {
+    public void setPage(Integer page) {
         this.page = page;
     }
 
-    public int getSize() {
+    public Integer getSize() {
         return size;
     }
 
-    public void setSize(int size) {
+    public void setSize(Integer size) {
         this.size = size;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/request/PostLikeRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/PostLikeRequest.java
@@ -1,8 +1,12 @@
 package com.fcgl.madrid.forum.model.request;
 
+import javax.validation.constraints.NotNull;
+
 public class PostLikeRequest {
 
+    @NotNull
     private Long userId;
+    @NotNull
     private Long postId;
 
     public PostLikeRequest(Long userId, Long postId) {
@@ -24,5 +28,13 @@ public class PostLikeRequest {
 
     public void setPostId(Long postId) {
         this.postId = postId;
+    }
+
+    @Override
+    public String toString() {
+        return "PostLikeRequest{" +
+                "userId=" + userId +
+                ", postId=" + postId +
+                '}';
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/request/PostRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/PostRequest.java
@@ -6,6 +6,7 @@ public class PostRequest {
     private String description;
     private Integer cityId;
     private Long userId;
+    private String userFirstName;
 
     /**
      * Request Parameters for post
@@ -14,11 +15,12 @@ public class PostRequest {
      * @param cityId
      * @param userId
      */
-    public PostRequest(String title, String description, Integer cityId, Long userId) {
+    public PostRequest(String title, String description, Integer cityId, Long userId, String userFirstName) {
         this.cityId = cityId;
         this.title = title;
         this.description = description;
         this.userId = userId;
+        this.userFirstName = userFirstName;
     }
 
     public String getDescription() {
@@ -51,5 +53,13 @@ public class PostRequest {
 
     public void setUserId(Long userId) {
         this.userId = userId;
+    }
+
+    public String getUserFirstName() {
+        return userFirstName;
+    }
+
+    public void setUserFirstName(String userFirstName) {
+        this.userFirstName = userFirstName;
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/response/GetCityPostsResponse.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/GetCityPostsResponse.java
@@ -2,15 +2,19 @@ package com.fcgl.madrid.forum.model.response;
 
 import com.fcgl.madrid.forum.dataModel.IBasicPost;
 import com.fcgl.madrid.forum.dataModel.Post;
+
+import java.time.Instant;
 import java.util.List;
 
 public class GetCityPostsResponse {
     private InternalStatus status;
-    private List<IBasicPost> posts;
+    private List<UserLikePost> posts;
+    private long timestamp;
 
-    public GetCityPostsResponse(InternalStatus status, List<IBasicPost> posts) {
+    public GetCityPostsResponse(InternalStatus status, List<UserLikePost> posts) {
         this.status = status;
         this.posts = posts;
+        this.timestamp = Instant.now().toEpochMilli();
     }
 
     public InternalStatus getStatus() {
@@ -21,11 +25,19 @@ public class GetCityPostsResponse {
         this.status = status;
     }
 
-    public List<IBasicPost> getPosts() {
+    public List<UserLikePost> getPosts() {
         return posts;
     }
 
-    public void setPosts(List<IBasicPost> posts) {
+    public void setPosts(List<UserLikePost> posts) {
         this.posts = posts;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/response/InternalStatus.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/InternalStatus.java
@@ -1,45 +1,58 @@
 package com.fcgl.madrid.forum.model.response;
 
+import org.springframework.http.HttpStatus;
+
 import java.util.List;
 import java.util.ArrayList;
 
 public class InternalStatus {
-    public static final InternalStatus OK = new InternalStatus(StatusCode.OK, 200, "ok");
-    public static final InternalStatus MISSING_PARAM = new InternalStatus(StatusCode.PARAM, 400, "Missing Required Param");
-    public static final InternalStatus NOT_FOUND = new InternalStatus(StatusCode.NOT_FOUND, 404, "Data Not Found");
+    public static final InternalStatus OK = new InternalStatus(StatusCode.OK, HttpStatus.OK, "ok");
+    public static final InternalStatus MISSING_PARAM = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, "Missing Required Param");
+    public static final InternalStatus NOT_FOUND = new InternalStatus(StatusCode.NOT_FOUND, HttpStatus.NOT_FOUND, "Data Not Found");
 
     private int code;
-    private int httpCode;
+    private HttpStatus httpCode;
     private List<String> messages;
 
     public InternalStatus() {
 
     }
 
-    public InternalStatus(StatusCode statusCode, int httpCode, String message) {
+    public InternalStatus(StatusCode statusCode, HttpStatus httpCode, String message) {
         this.code = statusCode.getCode();
         this.httpCode = httpCode;
         this.messages = new ArrayList<String>();
         this.messages.add(message);
     }
 
-    public InternalStatus(StatusCode statusCode, int httpCode, List<String> messages) {
+    public InternalStatus(StatusCode statusCode, HttpStatus httpCode, List<String> messages) {
         this.code = statusCode.getCode();
         this.httpCode = httpCode;
         this.messages = messages;
     }
 
-
     public int getCode() {
-        return this.code;
+        return code;
     }
 
-    public int getHttpCode() {
-        return this.httpCode;
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public HttpStatus getHttpCode() {
+        return httpCode;
+    }
+
+    public void setHttpCode(HttpStatus httpCode) {
+        this.httpCode = httpCode;
     }
 
     public List<String> getMessages() {
-        return this.messages;
+        return messages;
+    }
+
+    public void setMessages(List<String> messages) {
+        this.messages = messages;
     }
 
     public boolean equals(Object object) {
@@ -51,14 +64,14 @@ public class InternalStatus {
 
         if (code != that.code) return false;
         if (httpCode != that.httpCode) return false;
-        return messages.equals(that.messages);
+        return messages != null ? messages.equals(that.messages) : that.messages == null;
     }
 
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + code;
-        result = 31 * result + httpCode;
-        result = 31 * result + messages.hashCode();
+        result = 31 * result + (httpCode != null ? httpCode.hashCode() : 0);
+        result = 31 * result + (messages != null ? messages.hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/response/Response.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/Response.java
@@ -1,0 +1,27 @@
+package com.fcgl.madrid.forum.model.response;
+
+public class Response<T> {
+    private T response;
+    private InternalStatus status;
+
+    public Response(InternalStatus status, T response) {
+        this.status = status;
+        this.response = response;
+    }
+
+    public T getResponse() {
+        return response;
+    }
+
+    public void setResponse(T response) {
+        this.response = response;
+    }
+
+    public InternalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(InternalStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/model/response/StatusCode.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/StatusCode.java
@@ -5,6 +5,7 @@ public class StatusCode {
     public static final StatusCode OK = new StatusCode(1);
     public static final StatusCode PARAM = new StatusCode(2);
     public static final StatusCode NOT_FOUND = new StatusCode(3);
+    public static final StatusCode AUTH_ERROR = new StatusCode(4);
 
     private int code;
 

--- a/src/main/java/com/fcgl/madrid/forum/model/response/UserLikePost.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/response/UserLikePost.java
@@ -1,0 +1,33 @@
+package com.fcgl.madrid.forum.model.response;
+
+import com.fcgl.madrid.forum.dataModel.IBasicPost;
+
+public class UserLikePost {
+    private IBasicPost post;
+    private Boolean liked;
+
+    public UserLikePost() {
+
+    }
+
+    public UserLikePost(IBasicPost post, Boolean liked) {
+        this.post = post;
+        this.liked = liked;
+    }
+
+    public IBasicPost getPost() {
+        return post;
+    }
+
+    public void setPost(IBasicPost post) {
+        this.post = post;
+    }
+
+    public Boolean getLiked() {
+        return liked;
+    }
+
+    public void setLiked(Boolean liked) {
+        this.liked = liked;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
@@ -18,5 +18,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT u FROM Post u WHERE u.id = ?1")
     IBasicPost getPost(Long id);
 
-    List<IBasicPost> findAllByCityId(Integer cityId, Pageable pageable);
+    List<IBasicPost> findAllByCityIdOrderByCreatedDateDesc(Integer cityId, Pageable pageable);
 }

--- a/src/main/java/com/fcgl/madrid/forum/repository/UserLikeRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/UserLikeRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserLikeRepository extends JpaRepository<UserLike, Long>  {
 
-    UserLike findUserLikeByUserIdAndPost(Long userId, Post post);
+    UserLike findUserLikeByUserIdAndPostId(Long userId, Long postId);
 
     Integer countByPostId(Long postId);
 }

--- a/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
@@ -92,10 +92,10 @@ public class CommentService implements ICommentService {
                 messages.add(builder.toString());
             }
             // do something here
-            InternalStatus internalStatus = new InternalStatus(StatusCode.PARAM, 400, messages);
+            InternalStatus internalStatus = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, messages);
             return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.BAD_REQUEST);
         }
-        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, e.getMessage());
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -106,7 +106,7 @@ public class CommentService implements ICommentService {
      */
     private ResponseEntity<InternalStatus> fallback(CommentRequest commentRequest, Exception ex) {
         String message = "Fallback: " + ex.getMessage();
-        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, message);
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR, message);
         return new ResponseEntity<InternalStatus>(internalStatus, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -117,7 +117,7 @@ public class CommentService implements ICommentService {
      */
     private ResponseEntity<GetPostCommentResponse> fallback(GetPostCommentRequest request, Exception ex) {
         String message = "Fallback: " + ex.getMessage();
-        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, message);
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR, message);
         GetPostCommentResponse response = new GetPostCommentResponse(internalStatus, null);
         return new ResponseEntity<GetPostCommentResponse>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/test/java/com/fcgl/madrid/repository/CommentRepositoryIntegrationTest.java
+++ b/src/test/java/com/fcgl/madrid/repository/CommentRepositoryIntegrationTest.java
@@ -24,7 +24,7 @@ public class CommentRepositoryIntegrationTest {
 
     @Test
     public void findByIdTest() {
-        Post post1 = new Post("Looking for unit tests", "Anyone see any units tests in Madrid?", 1, new Long(1));
+        Post post1 = new Post("Looking for unit tests", "Anyone see any units tests in Madrid?", 1, new Long(1), "Jean Paul");
         entityManager.persist(post1);
         entityManager.flush();
         Long postId = post1.getId();


### PR DESCRIPTION
## Problem
Currently the native apps would have to make multiple request to get data on if a specific user has liked a post or not. We would like to instead return this during the initial request to get all the posts. The post request should now contain a userId. The response should contain data on if the use requesting the data has liked the post as well as the name of the person who made the post and a timestamp of when the request was made in order to comply with design requirements

## Solution
Endpoint `forum/post/v1/cityPosts` now takes in the following params: `cityId`, `page`, `size` ,`userId`

Response contains: 
```
{
    "status": {
        "code": 1,
        "httpCode": "OK",
        "messages": [
            "ok"
        ]
    },
    "posts": [
        {
            "post": {
                "description": "This is test number one",
                "userId": 1,
                "title": "Title 1",
                "cityId": 1,
                "userFirstName": "Jean Paul",
                "updatedDate": 1569398624529,
                "createdDate": 1569398624529,
                "userLikeCount": 0,
                "userCommentCount": 0,
                "id": 1
            },
            "liked": true
        },...],
    "timestamp": 1569398671754
}
```

## Testing:

1. Make the following request : `http://localhost:8082/forum/post/v1/cityPosts?cityId=1&page=0&size=10&userId=1` with the token from the README. 
    * Confirm that you get the expected data, test different inputs on the API