### PR TITLE
Add endpoints and logic for top and featured posts

### DIFF
--- a/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/PostController.java
@@ -48,7 +48,7 @@ public class PostController {
     }
 
     @PostMapping(path= "/post")
-    public ResponseEntity<InternalStatus> post(PostRequest postRequest) {
+    public ResponseEntity<InternalStatus> post(@Valid @RequestBody PostRequest postRequest) {
         return postService.post(postRequest);
     }
 
@@ -57,9 +57,19 @@ public class PostController {
         return postService.getPost(postId);
     }
 
-    @GetMapping(path="/cityPosts")
-    public ResponseEntity<GetCityPostsResponse> getCityPosts(@Valid GetCityPostsRequest request) {
-        return postService.getCityPosts(request);
+    @GetMapping(path="/cityPosts/new")
+    public ResponseEntity<GetCityPostsResponse> getCityPostsNew(@Valid GetCityPostsRequest request) {
+        return postService.getCityPostsNew(request);
+    }
+
+    @GetMapping(path="/cityPosts/featured")
+    public ResponseEntity<GetCityPostsResponse> getCityPostsFeatured(@Valid GetCityPostsRequest request) {
+        return postService.getCityPostsFeatured(request);
+    }
+
+    @GetMapping(path="/cityPosts/top")
+    public ResponseEntity<GetCityPostsResponse> getCityPostsTop(@Valid GetCityPostsRequest request) {
+        return postService.getCityPostsTop(request);
     }
 
     @PostMapping(path="/like")

--- a/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
+++ b/src/main/java/com/fcgl/madrid/forum/dataModel/Post.java
@@ -25,11 +25,11 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     @NotNull
-    @Size(min = 3, max = 40)
+    @Size(min = 3, max = 60)
     private String title;
     private String description;
-    private long createdDate;
-    private long updatedDate;
+    private Long createdDate;
+    private Long updatedDate;
     @NotNull
     private Integer cityId;//TODO: Think about location better than this
     @NotNull
@@ -37,6 +37,8 @@ public class Post {
     private Integer userLikeCount;
     private Integer userCommentCount;
     private String userFirstName;
+    private Long featuredPopularity;
+    private Long topPopularity;
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     @JsonManagedReference
@@ -49,6 +51,10 @@ public class Post {
     @PreUpdate
     public void preUpdate() {
         this.updatedDate = Instant.now().toEpochMilli();
+        this.featuredPopularity = (long) (this.userLikeCount + this.userCommentCount * 3);
+        long secondsSincePost = (this.updatedDate - this.createdDate) / 1000;
+        long daysSincePost = ((((secondsSincePost) / 60) / 60) / 24);
+        this.topPopularity = this.featuredPopularity - daysSincePost;
     }
 
     public Post() {
@@ -66,6 +72,8 @@ public class Post {
         this.userLikes = new ArrayList<UserLike>();
         this.userLikeCount = 0;
         this.userCommentCount = 0;
+        this.featuredPopularity = 0L;
+        this.topPopularity = 0L;
     }
 
     public Long getId() {
@@ -88,15 +96,15 @@ public class Post {
         this.description = description;
     }
 
-    public long getCreatedDate() {
+    public Long getCreatedDate() {
         return createdDate;
     }
 
-    public long getUpdatedDate() {
+    public Long getUpdatedDate() {
         return updatedDate;
     }
 
-    public void setUpdatedDate(long updatedDate) {
+    public void setUpdatedDate(Long updatedDate) {
         this.updatedDate = updatedDate;
     }
 
@@ -142,5 +150,21 @@ public class Post {
 
     public void setUserFirstName(String userFirstName) {
         this.userFirstName = userFirstName;
+    }
+
+    public Long getTopPopularity() {
+        return topPopularity;
+    }
+
+    public void setTopPopularity(Long topPopularity) {
+        this.topPopularity = topPopularity;
+    }
+
+    public Long getFeaturedPopularity() {
+        return featuredPopularity;
+    }
+
+    public void setFeaturedPopularity(Long featuredPopularity) {
+        this.featuredPopularity = featuredPopularity;
     }
 }

--- a/src/main/java/com/fcgl/madrid/forum/model/request/CommentRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/CommentRequest.java
@@ -11,7 +11,7 @@ public class CommentRequest {
     @NotNull
     private Long userId;
     @NotNull
-    private Post post;
+    private Long postId;
     @NotEmpty
     private String firstName;
 
@@ -19,13 +19,13 @@ public class CommentRequest {
      * Request Parameters for post
      * @param message
      * @param userId
-     * @param post
+     * @param postId
      * @param firstName
      */
-    public CommentRequest(String message, Long userId, Post post, String firstName){
+    public CommentRequest(String message, Long userId, Long postId, String firstName){
         this.message = message;
         this.userId = userId;
-        this.post = post;
+        this.postId = postId;
         this.firstName = firstName;
     }
 
@@ -37,12 +37,12 @@ public class CommentRequest {
         this.userId = userId;
     }
 
-    public Post getPost() {
-        return post;
+    public Long getPostId() {
+        return postId;
     }
 
-    public void setPost(Post post) {
-        this.post = post;
+    public void setPostId(Long postId) {
+        this.postId = postId;
     }
 
     public String getMessage() {

--- a/src/main/java/com/fcgl/madrid/forum/model/request/PostRequest.java
+++ b/src/main/java/com/fcgl/madrid/forum/model/request/PostRequest.java
@@ -1,11 +1,20 @@
 package com.fcgl.madrid.forum.model.request;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class PostRequest {
 
+    @NotEmpty
+    @Size(min = 3, max = 60)
     private String title;
     private String description;
+    @NotNull
     private Integer cityId;
+    @NotNull
     private Long userId;
+    @NotNull
     private String userFirstName;
 
     /**

--- a/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
+++ b/src/main/java/com/fcgl/madrid/forum/repository/PostRepository.java
@@ -19,4 +19,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     IBasicPost getPost(Long id);
 
     List<IBasicPost> findAllByCityIdOrderByCreatedDateDesc(Integer cityId, Pageable pageable);
+
+    List<IBasicPost> findAllByCityIdOrderByFeaturedPopularityDesc(Integer cityId, Pageable pageable);
+
+    List<IBasicPost> findAllByCityIdOrderByTopPopularityDesc(Integer cityId, Pageable pageable);
 }

--- a/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/CommentService.java
@@ -48,9 +48,10 @@ public class CommentService implements ICommentService {
     @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
     public ResponseEntity<InternalStatus> postComment(CommentRequest commentRequest) {
         try {
+            Post post = postRepository.findById(commentRequest.getPostId()).get();
             Comment comment = new Comment(
                     commentRequest.getMessage(),
-                    commentRequest.getPost(),
+                    post,
                     commentRequest.getUserId(),
                     commentRequest.getFirstname()
             );

--- a/src/main/java/com/fcgl/madrid/forum/service/PostService.java
+++ b/src/main/java/com/fcgl/madrid/forum/service/PostService.java
@@ -89,9 +89,27 @@ public class PostService implements IPostService {
     }
 
     @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
-    public ResponseEntity<GetCityPostsResponse> getCityPosts(GetCityPostsRequest request) {
+    public ResponseEntity<GetCityPostsResponse> getCityPostsNew(GetCityPostsRequest request) {
         Pageable pageConfig = PageRequest.of(request.getPage(), request.getSize());
         List<IBasicPost> posts = postRepository.findAllByCityIdOrderByCreatedDateDesc(request.getCityId(), pageConfig);
+        List<UserLikePost> userLikePosts = updatePostAttribute(posts, request.getUserId());
+        GetCityPostsResponse response = new GetCityPostsResponse(InternalStatus.OK, userLikePosts);
+        return new ResponseEntity<GetCityPostsResponse>(response, HttpStatus.OK);
+    }
+
+    @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
+    public ResponseEntity<GetCityPostsResponse> getCityPostsFeatured(GetCityPostsRequest request) {
+        Pageable pageConfig = PageRequest.of(request.getPage(), request.getSize());
+        List<IBasicPost> posts = postRepository.findAllByCityIdOrderByFeaturedPopularityDesc(request.getCityId(), pageConfig);
+        List<UserLikePost> userLikePosts = updatePostAttribute(posts, request.getUserId());
+        GetCityPostsResponse response = new GetCityPostsResponse(InternalStatus.OK, userLikePosts);
+        return new ResponseEntity<GetCityPostsResponse>(response, HttpStatus.OK);
+    }
+
+    @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
+    public ResponseEntity<GetCityPostsResponse> getCityPostsTop(GetCityPostsRequest request) {
+        Pageable pageConfig = PageRequest.of(request.getPage(), request.getSize());
+        List<IBasicPost> posts = postRepository.findAllByCityIdOrderByTopPopularityDesc(request.getCityId(), pageConfig);
         List<UserLikePost> userLikePosts = updatePostAttribute(posts, request.getUserId());
         GetCityPostsResponse response = new GetCityPostsResponse(InternalStatus.OK, userLikePosts);
         return new ResponseEntity<GetCityPostsResponse>(response, HttpStatus.OK);


### PR DESCRIPTION
## Problem

The frontend design requires three times of post categories: Featured, Top, and New. We currently only have support for New

## Solution

* Add two new endpoints for Featured and Top
* Add data points in Post table to keep track of `"popularity"` score. The Featured includes the most popular posts from the past year. The Top includes the most popular posts in the past month. 

## Test
* Try out the new endpoints and notice the different posts that are returned
* Confirm that the `new` endpoints is different than the `featured` and `top` endpoints by making new posts with different levels of popularity
TODO: Need a better algorithm for calculating `popularity`