### PR TITLE
Make post comment return the Comment object created

### DIFF
--- a/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
+++ b/src/main/java/com/fcgl/madrid/forum/controller/CommentController.java
@@ -1,9 +1,11 @@
 package com.fcgl.madrid.forum.controller;
 
+import com.fcgl.madrid.forum.dataModel.Comment;
 import com.fcgl.madrid.forum.model.request.CommentRequest;
 import com.fcgl.madrid.forum.model.request.GetPostCommentRequest;
 import com.fcgl.madrid.forum.model.response.GetPostCommentResponse;
 import com.fcgl.madrid.forum.model.response.InternalStatus;
+import com.fcgl.madrid.forum.model.response.Response;
 import com.fcgl.madrid.forum.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +24,7 @@ public class CommentController {
     }
 
     @PostMapping(path = "/postComment")
-    public ResponseEntity<InternalStatus> postComment(@Valid @RequestBody CommentRequest commentRequest) {
+    public ResponseEntity<Response<Comment>> postComment(@Valid @RequestBody CommentRequest commentRequest) {
         return commentService.postComment(commentRequest);
     }
 


### PR DESCRIPTION
## Problem

When a user posts a comment the state in the frontend is not updated to show their new comment

## Solution

Return the created comment object in the response when posting a comment so that the frontend can update their state

## Testing

Make an api request to make a comment and confirm that the comment object is returned in the response